### PR TITLE
Adding @Experiment decorator

### DIFF
--- a/test_decorator.py
+++ b/test_decorator.py
@@ -1,0 +1,24 @@
+import mock
+import pytest
+import laboratory
+from laboratory import Experiment
+
+def dummy_candidate_mismatch(x):
+    return False
+
+@Experiment(candidate=dummy_candidate_mismatch, raise_on_mismatch=True)
+def dummy_control_mismatch(x):
+    return True
+
+def dummy_candidate_match(x):
+    return True
+
+@Experiment(candidate=dummy_candidate_match, raise_on_mismatch=True)
+def dummy_control_match(x):
+    return True
+
+def test_decorated_functions():
+    with pytest.raises(laboratory.exceptions.MismatchException):
+        dummy_control_mismatch("blah")
+
+    dummy_control_match("blah")


### PR DESCRIPTION
@joealcorn 
This PR is for the decorator support we discussed in Issue #4.  I'll briefly outline the changes I've made:

1. In order to pass a `candidate` function to the decorator, we need to add another argument to `__init__()`.   So, `self._candidate` exists explicitly so that it can be invoked within the second (candidate) block inside the `decorate` method.

1. As for the decorator's implementation, I pretty much just wrapped up the standard usage.

1. I added `test_decorator.py` to test the implementation-- let me know if you think it needs additional test coverage.