### PR TITLE
Add __repr__ to Observation and Result

### DIFF
--- a/laboratory/observation.py
+++ b/laboratory/observation.py
@@ -48,3 +48,12 @@ class Observation(object):
     @property
     def duration(self):
         return self.end_time - self.start_time
+
+    def __repr__(self):
+        repr = "Observation(name={name!r}".format(name=self.name)
+        if hasattr(self, 'value'):
+            repr += ", value={value!r}".format(value=self.value)
+        if self.exception:
+            repr += ", exception={exception!r}".format(exception=self.exception)
+        repr += ")"
+        return repr

--- a/laboratory/result.py
+++ b/laboratory/result.py
@@ -10,3 +10,8 @@ class Result(object):
             self.experiment.compare(self.control, o)
             for o in self.observations
         ])
+
+    def __repr__(self):
+        return "Result(match={}, control={!r}, observations={!r})".format(
+            self.match, self.control, self.observations
+        )

--- a/test_experiment.py
+++ b/test_experiment.py
@@ -2,6 +2,7 @@ import mock
 import pytest
 
 import laboratory
+from laboratory.observation import Observation
 
 
 def raise_exception():
@@ -76,3 +77,24 @@ def test_set_context(publish):
     assert result.control.get_context() == {'ctx': True}
     assert result.observations[0].get_context() == {'ctx': False}
     assert result.observations[1].get_context() == {'ctx': True, 'additional': 1}
+
+
+def test_repr_without_value():
+    obs = Observation("an observation")
+
+    assert repr(obs) == "Observation(name='an observation')"
+
+
+def test_repr():
+    obs = Observation("an observation")
+    a_somewhat_complex_value = {'foo': 'bar'}
+    obs.record(a_somewhat_complex_value)
+
+    assert repr(obs) == """Observation(name='an observation', value={'foo': 'bar'})"""
+
+
+def test_repr_with_exception():
+    obs = Observation("an observation")
+    obs.set_exception(ValueError("something is wrong"))
+
+    assert repr(obs) == """Observation(name='an observation', exception=ValueError('something is wrong',))"""


### PR DESCRIPTION
Here is a PR for adding some information to repr() of Observation and Result.

This gives output like 

    Result(match=True, control=Observation(name=Control, value=<Item: Second / Default / >), observations=[Observation(name=Candidate, value=<Item: Second / Default / >)])

from `print(result)`, which helped me a lot, especially when starting out with laboratory and toying around.