### PR TITLE
Make observation always have a value attribute

### DIFF
--- a/laboratory/observation.py
+++ b/laboratory/observation.py
@@ -16,6 +16,12 @@ def Test(observation, raise_exceptions):
     finally:
         observation.set_end_time()
 
+class _Unrecorded(object):
+    def __repr__(self):
+        return "Unrecorded"
+
+unrecorded = _Unrecorded()
+
 
 class Observation(object):
     def __init__(self, name, context=None):
@@ -24,6 +30,7 @@ class Observation(object):
         self.exception = None
         self.exc_info = None
         self.context = context or {}
+        self.value = unrecorded
 
     def record(self, value):
         self.value = value
@@ -51,8 +58,7 @@ class Observation(object):
 
     def __repr__(self):
         repr = "Observation(name={name!r}".format(name=self.name)
-        if hasattr(self, 'value'):
-            repr += ", value={value!r}".format(value=self.value)
+        repr += ", value={value!r}".format(value=self.value)
         if self.exception:
             repr += ", exception={exception!r}".format(exception=self.exception)
         repr += ")"

--- a/test_experiment.py
+++ b/test_experiment.py
@@ -82,7 +82,7 @@ def test_set_context(publish):
 def test_repr_without_value():
     obs = Observation("an observation")
 
-    assert repr(obs) == "Observation(name='an observation')"
+    assert repr(obs) == "Observation(name='an observation', value=Unrecorded)"
 
 
 def test_repr():
@@ -97,4 +97,4 @@ def test_repr_with_exception():
     obs = Observation("an observation")
     obs.set_exception(ValueError("something is wrong"))
 
-    assert repr(obs) == """Observation(name='an observation', exception=ValueError('something is wrong',))"""
+    assert repr(obs) == """Observation(name='an observation', value=Unrecorded, exception=ValueError('something is wrong',))"""


### PR DESCRIPTION
When I was working on #7, I had to use hasattr to check if the Observation had a value attribute. This was a bit unexpected. I assume this is to know the difference between "No value has been returned" and "None was returned"?

This PR changes Observation to always have a `value` attribute, but to see the difference between "no value recorded" and "None returned" I created an instance of a new `_Unrecorded` class that is set to `value` in `__init__`. This object is exposed as `observation.unrecored`, so client code can do for example

```python
if observation.value is unrecorded:
    pass
```

Does this seem like a good change?