### PR TITLE
Move Experiment decorator to a different class.

### DIFF
--- a/laboratory/__init__.py
+++ b/laboratory/__init__.py
@@ -1,2 +1,2 @@
 from .exceptions import MismatchException
-from .experiment import Experiment
+from .experiment import Experiment, ExperimentDecorator

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,14 +1,14 @@
-import mock
 import pytest
 import laboratory
-from laboratory import Experiment
+from laboratory import ExperimentDecorator
 
 
 def dummy_candidate_mismatch(x):
     return False
 
 
-@Experiment(candidate=dummy_candidate_mismatch, raise_on_mismatch=True)
+@ExperimentDecorator(candidate=dummy_candidate_mismatch,
+                     raise_on_mismatch=True)
 def dummy_control_mismatch(x):
     return True
 
@@ -17,9 +17,19 @@ def dummy_candidate_match(x):
     return True
 
 
-@Experiment(candidate=dummy_candidate_match, raise_on_mismatch=True)
+@ExperimentDecorator(candidate=dummy_candidate_match, raise_on_mismatch=True)
 def dummy_control_match(x):
     return True
+
+
+def identity_candidate_match(x):
+    return x
+
+
+@ExperimentDecorator(candidate=identity_candidate_match,
+                     raise_on_mismatch=True)
+def identity_control_match(x):
+    return x
 
 
 def test_decorated_functions():
@@ -27,3 +37,8 @@ def test_decorated_functions():
         dummy_control_mismatch("blah")
 
     assert dummy_control_match("blah") == True
+
+
+def test_decorated_observations():
+    assert identity_control_match(0) == 0
+    assert identity_control_match(1) == 1


### PR DESCRIPTION
Hi, I found this module very useful and I wanted to use it to test a class method, so I used the decorator. 

After some testing I found out that the results of every call to my method were getting appended to `self._observations`. This happens because  `Experiment.__call__` is executed the first time the file containing my class is imported and with every call a new `Observation` instance gets appended to `self._observations` [here](https://github.com/joealcorn/laboratory/blob/master/laboratory/experiment.py#L34).

This is something that makes sense if we use the module like this:

```python
import laboratory

experiment = laboratory.Experiment()
with experiment.control() as c:
    c.record(get_objects_from_database())

with experiment.candidate() as c:
    c.record(get_objects_from_cache())

objects = experiment.run()
```

because we want all the observations at the end but not so much in the case of the decorator since we have to `publish` its one individually. Additionally, the `self._observations` list will continue to grow as long as the program is running and we keep calling the decorated function.

My change just moves the decorator in a different class and instantiates an `Experiment` every time the control function is executed. The default Experiment class is of course `laboratory.Experiment` but can be set also like this:

```python
@ExperimentDecorator(candidate=get_objects_from_cache, experiment_class=MyExperiment)
def get_objects_from_database():
    return True
```

or like this:

```python 
class MyExperimentDecorator(laboratory.ExperimentDecorator):
    experiment_class = MyExperiment
```

I modified the tests and added one that covers this case. 

Let me know what you think.

Thanks.