### PR TITLE
Add support for ordered execution in Experiment.conduct

### DIFF
--- a/laboratory/__init__.py
+++ b/laboratory/__init__.py
@@ -1,6 +1,6 @@
 from .exceptions import LaboratoryException, MismatchException
 from .experiment import Experiment
 
-__version__ = '1.0'
+__version__ = '1.0.1'
 
 __all__ = ('Experiment', 'LaboratoryException', 'MismatchException')

--- a/laboratory/experiment.py
+++ b/laboratory/experiment.py
@@ -108,11 +108,13 @@ class Experiment(object):
             'context': context or {},
         })
 
-    def conduct(self):
+    def conduct(self, randomize=True):
         '''
         Run control & candidate functions and return the control's return value.
         ``control()`` must be called first.
 
+        :param bool randomize: controls whether we shuffle the order
+            of execution between control and candidate
         :raise LaboratoryException: when no control case has been set
         :return: Control function's return value
         '''
@@ -137,7 +139,8 @@ class Experiment(object):
             get_func_executor(self._control, is_control=True),
         ] + [get_func_executor(cand, is_control=False,) for cand in self._candidates]
 
-        random.shuffle(funcs)
+        if randomize:
+            random.shuffle(funcs)
 
         control = None
         candidates = []

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -148,3 +148,28 @@ def test_functions_executed_in_random_order():
 
     control_indexes = [run_experiment() for i in range(5)]
     assert len(set(control_indexes)) > 1
+
+	
+def test_functions_executed_in_order():
+    # I'm basing this test on how we test random behavior. Instead of
+    # looking for variation, I want to look for consistency.
+    def run_experiment():
+        exp = laboratory.Experiment()
+        counter = {'index': 0}
+
+        def increment_counter():
+            counter['index'] += 1
+
+        def control_func():
+            return counter['index']
+
+        cand_func = mock.Mock(side_effect=increment_counter)
+
+        exp.control(control_func)
+        for _ in range(100):
+            exp.candidate(cand_func)
+
+        return exp.conduct(randomize=False)
+
+    control_indexes = [run_experiment() for i in range(5)]
+    assert set(control_indexes) == set([0])


### PR DESCRIPTION
This implements the behavior described in #18.

I called the kwarg `randomize` so the default is positive and backwards compatible. Earlier, I was thinking of calling this `preserve_order` which would default to `False`, but negative boolean logic is one step more complicated to follow than the positive for readability's sake. What do you think?