### PR TITLE
Implement OrderedExperiment to run variant functions in order of control then candidates without randomization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,3 @@ __pycache__/
 dist/
 build/
 docs/_build/
-.idea
-.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 dist/
 build/
 docs/_build/
+.idea
+.pytest_cache

--- a/laboratory/__init__.py
+++ b/laboratory/__init__.py
@@ -1,6 +1,7 @@
 from .exceptions import LaboratoryException, MismatchException
 from .experiment import Experiment
+from .experiment import OrderedExperiment
 
 __version__ = '1.0'
 
-__all__ = ('Experiment', 'LaboratoryException', 'MismatchException')
+__all__ = ('Experiment', 'OrderedExperiment', 'LaboratoryException', 'MismatchException')

--- a/laboratory/experiment.py
+++ b/laboratory/experiment.py
@@ -122,9 +122,11 @@ class Experiment(object):
         By default, variant functions in an Experiment are randomized before execution to
         help catch ordering issues.
 
-        :return: List of Function objects in random order
+        :return: List of Function objects wrapped by `self._get_func_executor` in random order
         """
-        candidate_executors = [self._get_func_executor(cand, is_control=False, ) for cand in self._candidates]
+        candidate_executors = [
+            self._get_func_executor(candidate, is_control=False, ) for candidate in self._candidates
+        ]
         funcs = [self._get_func_executor(self._control, is_control=True), ] + candidate_executors
         random.shuffle(funcs)
         return funcs
@@ -256,8 +258,9 @@ class OrderedExperiment(Experiment):
         By default, variant functions in an Experiment are randomized before execution to
         help catch ordering issues.
 
-        :return: List of Function objects in random order
+        :return: List of Function objects wrapped by `self._get_func_executor` in order of `control`
+            then the candidates in order of which they were set
         """
-        candidate_executors = [self._get_func_executor(cand, is_control=False, ) for cand in self._candidates]
+        candidate_executors = [self._get_func_executor(candidate, is_control=False, ) for candidate in self._candidates]
         funcs = [self._get_func_executor(self._control, is_control=True), ] + candidate_executors
         return funcs

--- a/laboratory/experiment.py
+++ b/laboratory/experiment.py
@@ -250,3 +250,14 @@ class OrderedExperiment(Experiment):
     OrderedExperiment is an Experiment that runs the variants without randomization,
     i.e. it will run the control function then the candidate function.
     """
+
+    def generate_variant_functions(self):
+        """
+        By default, variant functions in an Experiment are randomized before execution to
+        help catch ordering issues.
+
+        :return: List of Function objects in random order
+        """
+        candidate_executors = [self._get_func_executor(cand, is_control=False, ) for cand in self._candidates]
+        funcs = [self._get_func_executor(self._control, is_control=True), ] + candidate_executors
+        return funcs

--- a/laboratory/experiment.py
+++ b/laboratory/experiment.py
@@ -108,6 +108,27 @@ class Experiment(object):
             'context': context or {},
         })
 
+    def _get_func_executor(self, obs_def, is_control):
+        """A lightweight wrapper around a tested function in order to retrieve state
+
+        :param obs_def: dict - Observation definition, containing 'args', 'context', 'func', 'kwargs', and 'name'
+        :param is_control: bool - whether or not this is the control function
+        :return: Callable
+        """
+        return lambda *a, **kw: (self._run_tested_func(raise_on_exception=is_control, **obs_def), is_control)
+
+    def generate_variant_functions(self):
+        """
+        By default, variant functions in an Experiment are randomized before execution to
+        help catch ordering issues.
+
+        :return: List of Function objects in random order
+        """
+        candidate_executors = [self._get_func_executor(cand, is_control=False, ) for cand in self._candidates]
+        funcs = [self._get_func_executor(self._control, is_control=True), ] + candidate_executors
+        random.shuffle(funcs)
+        return funcs
+
     def conduct(self):
         '''
         Run control & candidate functions and return the control's return value.
@@ -127,17 +148,7 @@ class Experiment(object):
             control = self._run_tested_func(raise_on_exception=True, **self._control)
             return control.value
 
-        # otherwise, let's wrap an executor around all of our functions and randomise the ordering
-
-        def get_func_executor(obs_def, is_control):
-            """A lightweight wrapper around a tested function in order to retrieve state"""
-            return lambda *a, **kw: (self._run_tested_func(raise_on_exception=is_control, **obs_def), is_control)
-
-        funcs = [
-            get_func_executor(self._control, is_control=True),
-        ] + [get_func_executor(cand, is_control=False,) for cand in self._candidates]
-
-        random.shuffle(funcs)
+        funcs = self.generate_variant_functions()
 
         control = None
         candidates = []
@@ -232,3 +243,10 @@ class Experiment(object):
             raise exceptions.MismatchException(msg)
 
         return False
+
+
+class OrderedExperiment(Experiment):
+    """
+    OrderedExperiment is an Experiment that runs the variants without randomization,
+    i.e. it will run the control function then the candidate function.
+    """

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -148,3 +148,29 @@ def test_functions_executed_in_random_order():
 
     control_indexes = [run_experiment() for i in range(5)]
     assert len(set(control_indexes)) > 1
+
+
+def test_functions_executed_in_order():
+    # I'm basing this test on how we test random behavior. Instead of
+    # looking for variation, I want to look for consistency.
+
+    def run_experiment():
+        exp = laboratory.OrderedExperiment()
+
+        counter = {'index': 0}
+        def increment_counter():
+            counter['index'] += 1
+
+        def control_func():
+            return counter['index']
+
+        cand_func = mock.Mock(side_effect=increment_counter)
+
+        exp.control(control_func)
+        for _ in range(100):
+            exp.candidate(cand_func)
+
+        return exp.conduct()
+
+    control_indexes = [run_experiment() for i in range(5)]
+    assert set(control_indexes) == {0}


### PR DESCRIPTION
In #20, I suggested a class-based approach for implementing this functionality over the `randomize=True` kwarg approach.

After using this locally, I was pleased with having a base class to inherit from for my experiments. I feel like this approach is more explicit and flexible than what I originally proposed.

What do you think @joealcorn?