### PR TITLE
fix: rename compare param observation to candidate to match source code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,13 +194,13 @@ Controlling comparison
 
 Not all data is created equal. By default laboratory compares using ``==``, but
 sometimes you may need to tweak this to suit your needs.  It's easy enough |--|
-subclass ``Experiment`` and implement the ``compare(control, observation)`` method.
+subclass ``Experiment`` and implement the ``compare(control, candidate)`` method.
 
 .. code:: python
 
     class MyExperiment(Experiment):
-        def compare(self, control, observation):
-            return control.value['id'] == observation.value['id']
+        def compare(self, control, candidate):
+            return control.value['id'] == candidate.value['id']
 
 
 Raise on mismatch


### PR DESCRIPTION
The [source code](https://github.com/joealcorn/laboratory/blob/b8e81888b8ad509cef7ce1fef5e4defd10923668/laboratory/experiment.py#L174-L188) for the compare method has the parameters `control` and `candidate`. The [docs](https://github.com/joealcorn/laboratory/blob/master/README.rst#controlling-comparison) have parameters `control` and `observation`. 

This PR is meant to keep the docs consistent. :)